### PR TITLE
Synchronize both sides on mousewheel

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -367,8 +367,10 @@ if (typeof Slick === "undefined") {
                 if (jQuery.fn.mousewheel && options.frozenColumn > -1) {
                     if (options.frozenRow > -1) {
                         $viewportBottomL.mousewheel(handleMouseWheel);
+                        $viewportBottomR.mousewheel(handleMouseWheel);
                     } else {
                         $viewportTopL.mousewheel(handleMouseWheel);
+                        $viewportTopR.mousewheel(handleMouseWheel);
                     }
                 }
 


### PR DESCRIPTION
Currently if you scroll fast the frozen and non frozen rows become very jerky. It is hard to see on the example tables, but if you make them larger you will see that if you are scrolling on the right part of the table the left one is lagging behind. This makes them move at the same time. However, the problem still remains when using the scrollbar and not the mouse.
