### PR TITLE
Fix for issue #52 'onBeforeHeaderRowCellDestroy event triggered to late'

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -788,9 +788,6 @@ if (typeof Slick === "undefined") {
             $headerL.width(headersWidthL);
             $headerR.width(headersWidthR);
 
-            $headerRowL.empty();
-            $headerRowR.empty();
-
             $headerRow.find(".slick-headerrow-column")
                 .each(function() {
                     var columnDef = $(this).data("column");
@@ -801,7 +798,10 @@ if (typeof Slick === "undefined") {
                         });
                     }
                 });
-
+                
+            $headerRowL.empty();
+            $headerRowR.empty();
+            
             for (var i = 0; i < columns.length; i++) {
                 var m = columns[i];
 


### PR DESCRIPTION
Fix for issue #52 'onBeforeHeaderRowCellDestroy event triggered to late' https://github.com/JLynch7/SlickGrid/issues/52
