### PR TITLE
Frozen cell contents not appended when > 15 cols

### DIFF
--- a/examples/example-frozen-columns-and-rows.html
+++ b/examples/example-frozen-columns-and-rows.html
@@ -215,6 +215,18 @@
 		sortable: true
 	}];
 
+    for (var i = 5; i < 100; i += 1) {
+        columns.push({
+            id: "title" + i,
+            name: "Title"  + i,
+            field: "title"  + i,
+            cssClass: "cell-title",
+            editor: Slick.Editors.Text,
+            validator: requiredFieldValidator,
+            sortable: true
+        });
+    }
+
 	var columnFilters = {};
 
 	var options = {
@@ -328,6 +340,11 @@
 			d["title2"] = i;
 			d["title3"] = i;
 			d["title4"] = i;
+
+            for (var j = 5; j < 100; j += 1) {
+                d["title" + j] = i;
+            }
+
 		}
 
 

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1944,7 +1944,7 @@ if (typeof Slick === "undefined") {
                         appendCellHtml(stringArrayL, row, i, colspan, d);
                     }
                 } else if (( options.frozenColumn > -1 ) && ( i <= options.frozenColumn )) {
-                    appendCellHtml(stringArrayL, row, i, colspan);
+                    appendCellHtml(stringArrayL, row, i, colspan, d);
                 }
 
                 if (colspan > 1) {


### PR DESCRIPTION
This fixes an issue where the frozen cells show up blank when there is a large number of columns and the user has scrolled horizontally. 

to reproduce: 
1. on one of the example files add ~ 50 columns programatically with perhaps 100 rows (you have to scroll to trigger the virtual rendering). 
2. load the page and scroll horizontally towards the end of the list of columns
3. scroll vertically. Note that the frozen column cells remain blank
