### PR TITLE
Fixing Cell Not set On click event

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -800,10 +800,10 @@ if (typeof Slick === "undefined") {
                         });
                     }
                 });
-                
+
             $headerRowL.empty();
             $headerRowR.empty();
-            
+
             for (var i = 0; i < columns.length; i++) {
                 var m = columns[i];
 
@@ -3057,9 +3057,9 @@ if (typeof Slick === "undefined") {
                             ) {
                             scrollRowIntoView(cell.row, false);
                         }
-
-                        setActiveCellInternal(getCellNode(cell.row, cell.cell));
                     }
+
+                    setActiveCellInternal(getCellNode(cell.row, cell.cell));
                 }
             }
         }


### PR DESCRIPTION
If there were no frozen rows, then the cell would never be set on
a click event. It looks like this got accidentally placed inside
of this if a few months back during a code reformat:
5d35dd13229f7d34bde218eaaa3be95f6f3bedb3
as the previous commit did not have this inside of the if:
b0ff402a979e73f7d82ee32b0d657ae2af3f6697
