### PR TITLE
viewportTopR should always have 'auto' scroll

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1307,7 +1307,7 @@ if (typeof Slick === "undefined") {
 
             $viewportTopR.css({
                 'overflow-x': ( options.frozenColumn > -1 ) ? ( hasFrozenRows ) ? 'hidden' : 'scroll' : ( hasFrozenRows ) ? 'hidden' : 'auto',
-                'overflow-y': ( options.frozenColumn > -1 ) ? ( hasFrozenRows ) ? 'scroll' : 'auto' : ( hasFrozenRows ) ? 'scroll' : 'auto'
+                'overflow-y': 'auto'
             });
 
             $viewportBottomL.css({


### PR DESCRIPTION
This fixes an issue when you have the following configuration

`
options: {
  frozenColumn: 0,
  frozenRow: 1,
  frozenBottom: true
}
`

Basically, when you have a frozen bottom row w/ a frozen column, AND you have less rows than would fill up the height of the viewport, a disabled scrollbar is shown for the top right viewport, and it also visually overlaps the rightmost column.
