### PR TITLE
Adding a missing parameter

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1944,7 +1944,7 @@ if (typeof Slick === "undefined") {
                         appendCellHtml(stringArrayL, row, i, colspan, d);
                     }
                 } else if (( options.frozenColumn > -1 ) && ( i <= options.frozenColumn )) {
-                    appendCellHtml(stringArrayL, row, i, colspan);
+                    appendCellHtml(stringArrayL, row, i, colspan, d);
                 }
 
                 if (colspan > 1) {


### PR DESCRIPTION
parameter d was missing, causing frozen columns not rendered when the viewport is scrolled relatively far right.
